### PR TITLE
Add the ability to display the description instead of the title

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -16,6 +16,7 @@ if (isset($_POST['submit']))
     'stopautoplayontouch' => isset($_POST['stopautoplayontouch']),
     'loop' => isset($_POST['loop']),
     'enable_caption' => isset($_POST['enable_caption']),
+    'enable_caption_with' => $_POST['enable_caption_with'],
     'replace_picture' => isset($_POST['replace_picture']),
     'replace_picture_only_users' => isset($_POST['replace_picture_only_users']),
     'clicktransition_crossfade' => isset($_POST['clicktransition_crossfade']),

--- a/maintain.inc.php
+++ b/maintain.inc.php
@@ -18,6 +18,7 @@ class Fotorama_maintain extends PluginMaintain
     'fullscreen_nav' => 'false',
     'only_fullscreen' => false,
     'enable_caption' => false,
+    'enable_caption_with' => 'title',
     'thumbheight' => 64,
     'replace_picture' => false,
     'replace_picture_only_users' => false,

--- a/template/admin.tpl
+++ b/template/admin.tpl
@@ -133,8 +133,12 @@
   <li>
     <input type="checkbox" id="enable_caption" name="enable_caption"{if $Fotorama.enable_caption} checked="checked"{/if}>
     <label for="enable_caption">
-      <b>{'Show caption with image title'|translate}</b>
+      <b>{'Show caption with '|translate}</b>
     </label>
+    <select class="categoryDropDown" id="enable_caption_with" name="enable_caption_with">
+      <option value="title"{if $Fotorama.enable_caption_with == 'title'} selected="selected"{/if}>{'title'|translate}</option>
+      <option value="comment"{if $Fotorama.enable_caption_with == 'comment'} selected="selected"{/if}>{'description'|translate}</option>
+    </select>
   </li>
   <li>
     <input type="checkbox" id="replace_picture" name="replace_picture"{if $Fotorama.replace_picture} checked="checked"{/if}>
@@ -205,6 +209,13 @@
     else {
       jQuery('#period').prop('disabled', true);
     }
+
+    if(jQuery('#enable_caption').is(":checked")) {
+      jQuery('#enable_caption_with').prop('disabled', false);
+    }
+    else {
+      jQuery('#enable_caption_with').prop('disabled', true);
+    }
   }
   jQuery().ready(function() {
     update_Fotorama_state();
@@ -224,5 +235,7 @@
   jQuery('#autoplay').change(function() {
     update_Fotorama_state();
   });
-  
+  jQuery('#enable_caption').change(function() {
+    update_Fotorama_state();
+  });
 {/literal}{/footer_script}

--- a/template/fotorama-content.tpl
+++ b/template/fotorama-content.tpl
@@ -120,7 +120,7 @@
           data: [
 {foreach from=$items item=thumbnail}
 {
-caption: "{$thumbnail.TITLE|escape:javascript}",
+caption: "{if $Fotorama.enable_caption_with == 'comment' }{$thumbnail.comment|escape:javascript}{else}{$thumbnail.TITLE|escape:javascript}{/if}",
 full: "{str_replace('&amp;', '&', $thumbnail.derivative_big->get_url())}",
 img: "{str_replace('&amp;', '&', $thumbnail.derivative->get_url())}",
 {if $Fotorama_has_thumbs}


### PR DESCRIPTION
Prior to this patch, the Fotorama plugin allowed to display a caption
containing the title of the photo.
This patch introduces a choice and let the user decides to display
either the title or the description (comment) of the photo.
The default value is still to display title.

To test this patch, you must add description to some of the photos.
The caption should display the title.
Changing the "Show caption with" value with "description" should now
display the description.
