### PR TITLE
Fix #9: Display captions in fullscreen mode

### DIFF
--- a/template/fotorama-content.tpl
+++ b/template/fotorama-content.tpl
@@ -13,7 +13,7 @@
   data-shadows="{if $Fotorama.shadows}true{else}false{/if}" data-nav="{$Fotorama.nav}" data-fit="{$Fotorama.fit}"
   data-allowfullscreen="{$Fotorama.allowfullscreen}" data-autoplay="{if $Fotorama.autoplay}{$Fotorama.period}{else}false{/if}"
   data-transition="{$Fotorama.transition}" data-stopautoplayontouch="{if $Fotorama.stopautoplayontouch}true{else}false{/if}"
-  data-loop="{if $Fotorama.loop}true{else}false{/if}" data-captions="false" data-thumbheight="{$Fotorama.thumbheight}"
+  data-loop="{if $Fotorama.loop}true{else}false{/if}" data-captions:"{if $Fotorama.enable_caption}true{else}false{/if}" data-thumbheight="{$Fotorama.thumbheight}"
   data-thumbwidth="{$Fotorama.thumbheight}"{if $Fotorama.clicktransition_crossfade} data-clicktransition="crossfade"{/if}
   data-keyboard="true">
 </div>
@@ -80,9 +80,6 @@
             function (e, fotorama, extra) {
               fotorama.setOptions({
                 nav: "{$Fotorama.fullscreen_nav}",
-                {if $Fotorama.enable_caption}
-                captions: "true",
-                {/if}
               });
               {if $Fotorama.autoplay}
               fotorama.startAutoplay();
@@ -104,9 +101,6 @@
 
               fotorama.setOptions({
                 nav: "{$Fotorama.nav}",
-                {if $Fotorama.enable_caption}
-                captions: "false",
-                {/if}
               });
 
               update_picture(fotorama);


### PR DESCRIPTION
This patch displays the captions depending on the enable_caption flag.