### PR TITLE
Fix #2: Update the close and info links in fullscren mode

### DIFF
--- a/template/fotorama-content.tpl
+++ b/template/fotorama-content.tpl
@@ -54,9 +54,7 @@
         // Listen to the events
         .on('fotorama:showend',
             function (e, fotorama, extra) {
-              if (!fullscreen) {
                 update_picture(fotorama);
-              }
 							{if !empty($view_borders)}
 {if $view_borders[0] < $view_borders[1]}
 								if (fotorama.activeIndex <= {$view_borders[0]}{if $Fotorama_has_thumbs}+5{/if} ||


### PR DESCRIPTION
In slideshow mode: the close (x) and info (i) links don't behave the
same in fullscreen and non-fullscreen modes.
In fullscreen mode, the links are not updated with the current image url
and point to the first image when the fullscreen has been launched.