### PR TITLE
Fix #4: Add Play/Pause buttons

### DIFF
--- a/template/fotorama-content.tpl
+++ b/template/fotorama-content.tpl
@@ -25,7 +25,27 @@
 
 {footer_script require='jquery'}
   window.blockFotoramaData = true;
-  
+
+  $( '#play_link' ).on( "click", function( event ) {
+    event.preventDefault();
+    var link, span, text;
+    link = document.getElementById("play_link");
+    span = document.getElementById("play_span");
+    text = document.getElementById("play_text");
+    if (span.className == "pwg-icon pwg-icon-play") {
+      jQuery('.fotorama').data('fotorama').stopAutoplay();
+      link.title = "Pause slideshow";
+      text.innerHTML = "Pause slideshow";
+      span.className = "pwg-icon pwg-icon-pause";
+    } else {
+      jQuery('.fotorama').data('fotorama').setOptions({literal}{autoplay:{/literal}{if $Fotorama.autoplay}{$Fotorama.period}{else}false{/if}{literal}}{/literal});
+      jQuery('.fotorama').data('fotorama').startAutoplay();
+      link.title = "Play slideshow";
+      text.innerHTML = "Play slideshow";
+      span.className = "pwg-icon pwg-icon-play";
+    }
+  });
+
   function update_picture(fotorama) {
     {if isset($replace_picture)}
     if (history.replaceState)

--- a/template/fotorama.tpl
+++ b/template/fotorama.tpl
@@ -15,6 +15,16 @@ var image_h = {$item_height};
 
   <div id="imageToolBar">
 	<div class="imageNumber">{$PHOTO}</div>
+    <div class="navigationButtons">
+        <a href="#" id='play_link' onlick="toggle_play();" title="Pause slideshow">
+        {if $Fotorama.autoplay}
+        <span id='play_span' class="pwg-icon pwg-icon-pause"></span><span id="play_text" class="pwg-button-text">Pause slideshow</span>
+        {else}
+        <span id='play_span' class="pwg-icon pwg-icon-play"></span><span id="play_text" class="pwg-button-text">Play slideshow</span>
+        {/if}
+        </a>
+    </div>
+
   </div>
 
   <div id="content">


### PR DESCRIPTION
This patch adds the ability to start or stop the autoplay feature

To test it, open Fotorama and make sure that the button are nicely
displayed and works as expected.
Note the buttons are not displayed in fullscreen mode.