### PR TITLE
Feature #6: Video Integration

### DIFF
--- a/admin.php
+++ b/admin.php
@@ -16,7 +16,7 @@ if (isset($_POST['submit']))
     'stopautoplayontouch' => isset($_POST['stopautoplayontouch']),
     'loop' => isset($_POST['loop']),
     'enable_caption' => isset($_POST['enable_caption']),
-    'enable_caption_with' => $_POST['enable_caption_with'],
+    'enable_caption_with' => isset($_POST['enable_caption_with']) ? $_POST['enable_caption_with'] : 'title',
     'replace_picture' => isset($_POST['replace_picture']),
     'replace_picture_only_users' => isset($_POST['replace_picture_only_users']),
     'clicktransition_crossfade' => isset($_POST['clicktransition_crossfade']),

--- a/main.inc.php
+++ b/main.inc.php
@@ -1,9 +1,9 @@
 <?php
 /*
 Plugin Name: Fotorama
-Version: auto
+Version: 2.7.r
 Description: Fotorama based full-screen slideshow
-Plugin URI: auto
+Plugin URI: http://piwigo.org/ext/extension_view.php?eid=727
 Author: JanisV
 */
 
@@ -243,6 +243,15 @@ function Fotorama_end_picture()
 
     $row['TITLE'] = render_element_name($row);
     $row['DESCRIPTION'] = render_element_description($row);
+
+    // VJS integration, is plugin VJS install and it is a supported video file by the plugin
+    if (function_exists('vjs_valid_extension') and function_exists('vjs_get_mimetype_from_ext')) {
+        if (vjs_valid_extension(get_extension($row['path'])) === true) {
+            $row['video'] = $row['path'];
+            $row['video_type'] = vjs_get_mimetype_from_ext(get_extension($row['path']));
+	}
+    }
+
     $picture[] = $row;
   }
   $picture = trigger_change('fotorama_items', $picture, $selection);
@@ -346,3 +355,4 @@ function ws_Fotorama_log_history($params, &$service)
     array('id' => $history_id)
     );
 }
+?>

--- a/template/fotorama-content.tpl
+++ b/template/fotorama-content.tpl
@@ -20,7 +20,7 @@
 
 {foreach from=$items item=thumbnail}
   <div 
-data-caption="{if $Fotorama.enable_caption_with == 'comment' }{$thumbnail.comment|escape:javascript}{else}{$thumbnail.TITLE|escape:javascript}{/if}"
+data-caption="{if $Fotorama.enable_caption_with == 'comment' }{$thumbnail.DESCRIPTION|escape:javascript}{else}{$thumbnail.TITLE|escape:javascript}{/if}"
 data-url="{$thumbnail.url}"
 data-id="{$thumbnail.id}"
 {if $Fotorama_has_thumbs}

--- a/template/fotorama-content.tpl
+++ b/template/fotorama-content.tpl
@@ -15,7 +15,8 @@
   data-transition="{$Fotorama.transition}" data-stopautoplayontouch="{if $Fotorama.stopautoplayontouch}true{else}false{/if}"
   data-loop="{if $Fotorama.loop}true{else}false{/if}" data-captions:"{if $Fotorama.enable_caption}true{else}false{/if}" data-thumbheight="{$Fotorama.thumbheight}"
   data-thumbwidth="{$Fotorama.thumbheight}"{if $Fotorama.clicktransition_crossfade} data-clicktransition="crossfade"{/if}
-  data-keyboard="true">
+  data-keyboard="true"
+  data-click="false">
 
 {foreach from=$items item=thumbnail}
   <div 
@@ -50,26 +51,6 @@ data-full="{str_replace('&amp;', '&', $thumbnail.derivative_big->get_url())}">
 {footer_script require='jquery'}
   window.blockFotoramaData = true;
 
-  $( '#play_link' ).on( "click", function( event ) {
-    event.preventDefault();
-    var link, span, text;
-    link = document.getElementById("play_link");
-    span = document.getElementById("play_span");
-    text = document.getElementById("play_text");
-    if (span.className == "pwg-icon pwg-icon-play") {
-      jQuery('.fotorama').data('fotorama').stopAutoplay();
-      link.title = "Pause slideshow";
-      text.innerHTML = "Pause slideshow";
-      span.className = "pwg-icon pwg-icon-pause";
-    } else {
-      jQuery('.fotorama').data('fotorama').setOptions({literal}{autoplay:{/literal}{if $Fotorama.autoplay}{$Fotorama.period}{else}false{/if}{literal}}{/literal});
-      jQuery('.fotorama').data('fotorama').startAutoplay();
-      link.title = "Play slideshow";
-      text.innerHTML = "Play slideshow";
-      span.className = "pwg-icon pwg-icon-play";
-    }
-  });
-
   function update_picture(fotorama) {
     {if isset($replace_picture)}
     if (history.replaceState)
@@ -81,50 +62,43 @@ data-full="{str_replace('&amp;', '&', $thumbnail.derivative_big->get_url())}">
     {/if}
 
     if (fotorama.activeFrame['isvideo']) {
-	var player;
-	player = document.getElementById("my_video_"+fotorama.activeFrame['id']);
-	console.log(player);
-	console.log("Duration:"+player.duration);
-	if (player.networkState == 3) {
-		console.log("Error! Media resource could not be decoded. Next...");
-		// Next on error
-		fotorama.show('>');
-	}
-	if (!isNaN(player.duration)) {
-		var runtime;
-		runtime = Math.round(player.duration*1000); // in millsecond
-		{if $Fotorama.autoplay}
-		fotorama.setOptions({literal}{autoplay:runtime}{/literal}); // update fotorama options
-		{/if}
-		console.log("Autoplay Runtime:"+runtime);
-	}
-	// Stop fotorama
-	fotorama.stopAutoplay();
-	// Rewind the begining
-	player.currentTime = 0;
-	player.seeking = false;
-	// Start video
-	{if $Fotorama.autoplay}
-	player.play();
-	{/if}
-	//player.autoplay=true;
-	// Set video player events
-	player.onended = function(e) {
-		{if $Fotorama.autoplay}
-		console.log('Video ended Next...');
-		// Next on end
-		fotorama.show('>');
-		{/if}
-	}
-	player.onerror = function(e) {
-		console.log('Video error Next...');
-		// Next on error
-		fotorama.show('>');
-	}
-	player.onplay = function(e) {
-		console.log('Video play stopAutoplay...');
-		fotorama.stopAutoplay();
-	}
+        var player;
+        player = document.getElementById("my_video_"+fotorama.activeFrame['id']);
+        if (player.networkState == 3) {
+            // Next on error
+            fotorama.show('>');
+        }
+        if (!isNaN(player.duration)) {
+            var runtime;
+            runtime = Math.round(player.duration*1000); // in millsecond
+            {if $Fotorama.autoplay}
+            //fotorama.setOptions({literal}{autoplay:runtime}{/literal}); // update fotorama options
+            {/if}
+        }
+        // Stop fotorama
+        fotorama.stopAutoplay();
+        // Rewind the begining
+        player.currentTime = 0;
+        player.seeking = false;
+        // Start video
+        {if $Fotorama.autoplay}
+        player.play();
+        {/if}
+        //player.autoplay=true;
+        // Set video player events
+        player.onended = function(e) {
+            {if $Fotorama.autoplay}
+            // Next on end
+            fotorama.show('>');
+            {/if}
+        }
+        player.onerror = function(e) {
+            // Next on error
+            fotorama.show('>');
+        }
+        player.onplay = function(e) {
+            fotorama.stopAutoplay();
+        }
     } else {
 	// Revert the settings if image
 	fotorama.setOptions({literal}{autoplay:{/literal}{if $Fotorama.autoplay}{$Fotorama.period}{else}false{/if}{literal}}{/literal});
@@ -258,21 +232,6 @@ url: "{$thumbnail.url}"
   {if $Fotorama.info_button}
   jQuery('.fotorama').on('fotorama:ready', function (e, fotorama) {
     jQuery('.fotorama__info-icon').detach().insertAfter('.fotorama__fullscreen-icon');
-  });
-  {/if}
-  
-  {if $Fotorama.autoplay}
-  $(document).keypress(function(e) {
-    if(e.which == 43) {
-      jQuery('.fotorama').data('fotorama').setOptions({
-        autoplay: jQuery('.fotorama').data('fotorama').options['autoplay'] * 1.4
-      });
-    }
-    if(e.which == 45) {
-      jQuery('.fotorama').data('fotorama').setOptions({
-        autoplay: jQuery('.fotorama').data('fotorama').options['autoplay'] / 1.4
-      });
-    }
   });
   {/if}
 {/footer_script}

--- a/template/fotorama-content.tpl
+++ b/template/fotorama-content.tpl
@@ -20,7 +20,7 @@
 
 {foreach from=$items item=thumbnail}
   <div 
-data-caption="{if $Fotorama.enable_caption_with == 'comment' }{$thumbnail.DESCRIPTION|escape:javascript}{else}{$thumbnail.TITLE|escape:javascript}{/if}"
+data-caption="{if $Fotorama.enable_caption_with == 'comment' }{$thumbnail.DESCRIPTION|escape:html}{else}{$thumbnail.TITLE|escape:html}{/if}"
 data-url="{$thumbnail.url}"
 data-id="{$thumbnail.id}"
 {if $Fotorama_has_thumbs}

--- a/template/fotorama.tpl
+++ b/template/fotorama.tpl
@@ -15,16 +15,6 @@ var image_h = {$item_height};
 
   <div id="imageToolBar">
 	<div class="imageNumber">{$PHOTO}</div>
-    <div class="navigationButtons">
-        <a href="#" id='play_link' onlick="toggle_play();" title="Pause slideshow">
-        {if $Fotorama.autoplay}
-        <span id='play_span' class="pwg-icon pwg-icon-pause"></span><span id="play_text" class="pwg-button-text">Pause slideshow</span>
-        {else}
-        <span id='play_span' class="pwg-icon pwg-icon-play"></span><span id="play_text" class="pwg-button-text">Play slideshow</span>
-        {/if}
-        </a>
-    </div>
-
   </div>
 
   <div id="content">


### PR DESCRIPTION
This path allow to view video using the default player and only for MP4 file.
For some reason I have to remove this data-auto="false", to be clarify...
There is still limitation on the timeout slide, require fotorama.stopAutoplay() somewhere or manipulating fotorama.setOptions(options).