### PR TITLE
Fix info button on first page display

### DIFF
--- a/template/fotorama-content.tpl
+++ b/template/fotorama-content.tpl
@@ -230,6 +230,8 @@ url: "{$thumbnail.url}"
   });
   {/if}
   {if $Fotorama.info_button}
+  jQuery('a.fotorama__info-icon').attr('href',
+    window.location.href+(window.location.href.indexOf('?')==-1 ? '?' : '&')+'slidestop=');
   jQuery('.fotorama').on('fotorama:ready', function (e, fotorama) {
     jQuery('.fotorama__info-icon').detach().insertAfter('.fotorama__fullscreen-icon');
   });


### PR DESCRIPTION
The info button's target was set in update_picture(), which is called when the picture changes. As a consequence, the button was inactive before the first image change.

Fix this by setting an initial href value for the button when loading the page.